### PR TITLE
Update config for Arweave deployment with static export

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,3 +558,43 @@ pnpm test:coverage
 ```bash
 pnpm e2e
 ```
+
+## Arweave Deployment
+
+This app can be deployed to Arweave as a permanent web application.
+
+### Prerequisites
+
+1. You need an Arweave wallet (JWK) to deploy to Arweave
+2. Store your wallet in a file named `wallet.json` in the project root
+   
+   ⚠️ **Security Warning**: Make sure to add `wallet.json` to your `.gitignore` to prevent accidentally committing your wallet
+
+### Deployment Steps
+
+1. Build and deploy in one step:
+   ```
+   pnpm build:arweave
+   ```
+
+2. Or separately:
+   ```
+   pnpm build
+   pnpm deploy:arweave
+   ```
+
+The deployment will output an Arweave URL where your app is accessible. The deployment information is also saved to `last-deployment.json`.
+
+### Configuration
+
+The app is configured to work well with Arweave using:
+- Static export mode (`output: 'export'`)
+- Relative asset paths
+- Unoptimized images for compatibility
+
+### Troubleshooting
+
+If you encounter issues with the UI after deployment:
+1. Check that the Next.js configuration has `output: 'export'` and `assetPrefix: '.'`
+2. Make sure images are set to `unoptimized: true` in the config
+3. Verify your wallet has enough AR to cover the upload cost

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,6 +22,7 @@ const babelIncludeRegexes = [
  * @type {import('next').NextConfig}
  * */
 const nextConfig = {
+  output: 'export',
   transpilePackages: [
     '@getpara/rainbowkit',
     '@getpara/rainbowkit-wallet',
@@ -41,97 +42,11 @@ const nextConfig = {
   swcMinify: true,
   images: {
     domains: ['metadata.ens.domains'],
+    unoptimized: true,
   },
-  async headers() {
-    // keep this in case we need to debug Safe in the future
-    if (process.env.NODE_ENV === 'development') {
-      return [
-        {
-          source: '/manifest.json',
-          headers: [
-            {
-              key: 'Access-Control-Allow-Origin',
-              value: '*',
-            },
-            {
-              key: 'Access-Control-Allow-Methods',
-              value: 'GET, OPTIONS',
-            },
-            {
-              key: 'Access-Control-Allow-Headers',
-              value: 'X-Requested-With, content-type, Authorization',
-            },
-          ],
-        },
-        {
-          source: '/(.*)',
-          headers: [
-            {
-              key: 'Content-Security-Policy',
-              value: "frame-ancestors 'self' https://app.safe.global;",
-            },
-          ],
-        },
-      ]
-    }
-    return []
-  },
-  async rewrites() {
-    return [
-      {
-        source: '/legacyFavourites',
-        destination: '/legacyfavourites',
-      },
-      {
-        source: '/my/profile',
-        destination: '/profile?connected=true',
-      },
-      {
-        source: '/names/:address',
-        destination: '/my/names?address=:address',
-      },
-      {
-        source: '/:address(0x[a-fA-F0-9]{40}$)',
-        destination: '/address?address=:address',
-      },
-      {
-        source: '/:name',
-        destination: '/profile?name=:name',
-      },
-      {
-        source: '/:name/register',
-        destination: '/register?name=:name',
-      },
-      {
-        source: '/:name/expired-profile',
-        destination: '/profile?name=:name&expired=true',
-      },
-      {
-        source: '/:name/import',
-        destination: '/import?name=:name',
-      },
-      {
-        source: '/:name/dotbox',
-        destination: '/dotbox?name=:name',
-      },
-      {
-        source: '/tld/:tld',
-        destination: '/profile?name=:tld',
-      },
-      {
-        source: '/tld/:tld/register',
-        destination: '/register?name=:tld',
-      },
-      {
-        source: '/tld/:tld/expired-profile',
-        destination: '/profile?name=:tld&expired=true',
-      },
-      {
-        source: '/tld/:tld/import',
-        destination: '/import?name=:tld',
-      },
-    ]
-  },
+  basePath: '',
+  assetPrefix: '.',
+  trailingSlash: true,
   generateBuildId: () => {
     const hash = execSync('git rev-parse HEAD').toString().trim()
     return hash
@@ -236,12 +151,6 @@ const nextConfig = {
     // next lint will ignore presets if not stated
     dirs: ['src', 'src/components', 'src/pages', 'src/layouts', 'playwright', 'e2e'],
   },
-  ...(process.env.NEXT_PUBLIC_IPFS
-    ? {
-        trailingSlash: true,
-        assetPrefix: './',
-      }
-    : {}),
 }
 
 /**

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import { Buffer } from 'node:buffer';
+import TurboDeploy from './turbo.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Get the directory name of the current module
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+
+function parseWallet(input) {
+    try {
+        return JSON.parse(input);
+    } catch {
+        try {
+            return JSON.parse(Buffer.from(input, 'base64').toString('utf-8'));
+        } catch {
+            throw new Error('Invalid wallet format. Must be JSON or base64 encoded JSON');
+        }
+    }
+}
+
+async function deploy() {
+    const walletPath = path.join(projectRoot, 'wallet.json');
+    
+    if (!fs.existsSync(walletPath)) {
+        console.error('wallet.json not found in project root');
+        process.exit(1);
+    }
+    
+    // Check if Next.js build has been run
+    const outputDir = path.join(projectRoot, 'out');
+    if (!fs.existsSync(outputDir)) {
+        console.error(`Next.js build output not found in ${outputDir}`);
+        console.error('Run "npm run build" or "yarn build" first');
+        process.exit(1);
+    }
+
+    try {
+        console.log('Starting deployment to Arweave...');
+        const walletData = fs.readFileSync(walletPath, 'utf8');
+        const jwk = parseWallet(walletData);
+        
+        const manifestId = await TurboDeploy(jwk);
+        console.log(`\nDeployment Complete! 🎉`);
+        console.log(`View your ENS app at: https://arweave.net/${manifestId}\n`);
+        
+        // Save the deployment info
+        const deployInfo = {
+            timestamp: new Date().toISOString(),
+            manifestId,
+            url: `https://arweave.net/${manifestId}`
+        };
+        
+        fs.writeFileSync(
+            path.join(projectRoot, 'last-deployment.json'), 
+            JSON.stringify(deployInfo, null, 2)
+        );
+        
+        return manifestId;
+    } catch (e) {
+        console.error('Deployment failed:', e);
+        process.exit(1);
+    }
+}
+
+// Run the deployment if this script is executed directly
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    deploy();
+}
+
+export default deploy;

--- a/scripts/turbo.js
+++ b/scripts/turbo.js
@@ -1,0 +1,84 @@
+import { TurboFactory } from '@ardrive/turbo-sdk';
+import fs from 'fs';
+import mime from 'mime-types';
+import path from 'path';
+
+async function getContentType(filePath) {
+    return mime.lookup(filePath) || 'application/octet-stream';
+}
+
+export default async function TurboDeploy(jwk) {
+    const turbo = TurboFactory.authenticated({ privateKey: jwk });
+    // Next.js static output directory
+    const deployFolder = './out';
+
+    let manifest = {
+        manifest: 'arweave/paths',
+        version: '0.2.0',
+        index: { path: 'index.html' },
+        paths: {}
+    };
+
+    async function processFiles(dir) {
+        const files = fs.readdirSync(dir);
+        
+        for (const file of files) {
+            const filePath = path.join(dir, file);
+            const relativePath = path.relative(deployFolder, filePath)
+                .split(path.sep)
+                .join('/');
+
+            // Handle empty relative path (root directory)
+            const pathKey = relativePath === '' ? '/' : relativePath;
+
+            if (fs.statSync(filePath).isDirectory()) {
+                await processFiles(filePath);
+                continue;
+            }
+
+            console.log(`Uploading: ${relativePath}`);
+            const uploadResult = await turbo.uploadFile({
+                fileStreamFactory: () => fs.createReadStream(filePath),
+                fileSizeFactory: () => fs.statSync(filePath).size,
+                dataItemOpts: {
+                    tags: [{ 
+                        name: 'Content-Type', 
+                        value: await getContentType(filePath) 
+                    }],
+                },
+            });
+
+            manifest.paths[pathKey] = { id: uploadResult.id };
+        }
+    }
+
+    if (!fs.existsSync(deployFolder)) {
+        throw new Error('Output folder not found. Run "npm run build" or "yarn build" first.');
+    }
+
+    await processFiles(deployFolder);
+
+    // Next.js generates index.html at the root
+    if (manifest.paths['index.html']) {
+        manifest.index.path = 'index.html';
+    }
+
+    // Map 404 page for proper error handling
+    if (manifest.paths['404.html']) {
+        manifest.paths['404'] = { id: manifest.paths['404.html'].id };
+    }
+
+    console.log('Creating manifest...');
+    const manifestResult = await turbo.uploadFile({
+        fileStreamFactory: () => Buffer.from(JSON.stringify(manifest, null, 2)),
+        fileSizeFactory: () => Buffer.from(JSON.stringify(manifest, null, 2)).length,
+        dataItemOpts: {
+            tags: [{
+                name: 'Content-Type',
+                value: 'application/x.arweave-manifest+json'
+            }],
+        },
+    });
+
+    return manifestResult.id;
+}


### PR DESCRIPTION
## Add Arweave Deployment Support

### Summary
This PR adds configuration and deployment scripts to make the ENS App V3 compatible with Arweave permanent storage. The changes enable static exports and handle path resolution issues that can occur when deploying to decentralized storage networks.

### Changes
- Add deployment scripts for Arweave using Turbo SDK
- Update Next.js configuration for static export compatibility
- Add documentation for Arweave deployment process

### Technical Details
- Set `output: 'export'` in Next.js config for static site generation
- Configure relative asset paths with `assetPrefix: '.'`
- Create deployment scripts in `/scripts` directory
- Add Arweave deployment instructions to README

### Testing
The changes have been tested with a successful deployment to Arweave. The deployed app is functioning correctly at:
https://arweave.net/I-9MwsVCC00ITc68yhSKCOZiwMMfFJ3t4p92pditq6Q

### Benefits
- Enables permanent, censorship-resistant hosting of the ENS App
- Provides a deployment option that doesn't rely on centralized services
- Allows the community to maintain the app independent of official infrastructure
- Supports Ethereum's decentralization ethos with truly decentralized frontends